### PR TITLE
Remove superfluous flags from Arduino CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Compile your project with coredump support:
 -D CONFIG_ESP_COREDUMP_STACK_SIZE=1792 \
 -D CONFIG_ESP_COREDUMP_MAX_TASKS_NUM=64 \
 -D CONFIG_ESP_COREDUMP_CHECK_BOOT=1" \
-  src/esp32backtracetest \
-  --additional-urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
+  src/esp32backtracetest
 ```
 
 ### Upload
@@ -53,8 +52,7 @@ Upload the firmware to your board:
 ./arduino-cli upload \
   --fqbn esp32:esp32:esp32da \
   --port /dev/cu.usbserial-0001 \
-  src/esp32backtracetest \
-  --additional-urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
+  src/esp32backtracetest
 ```
 
 > **ⓘ** Use `./arduino-cli board list` to find your device's port.


### PR DESCRIPTION
**Arduino CLI**'s [`--additional-urls` flag](https://arduino.github.io/arduino-cli/dev/commands/arduino-cli/#options) allows the user to supply from the command line the URLs of [package indexes](https://arduino.github.io/arduino-cli/latest/package_index_json-specification/) for platforms that are not provided via the [primary package index](https://downloads.arduino.cc/packages/package_index.json).

During the early phase of **Arduino CLI**'s development, I believe it was necessary to add this flag in every command that involved the dependent platform, and this is why the flag was added to the [root command](https://arduino.github.io/arduino-cli/dev/commands/arduino-cli/). However, that onerous requirement was removed long ago and now the flag is only required in the commands that use the URL.

In this project, the only Arduino CLI command that uses the URL is [`core install`](https://arduino.github.io/arduino-cli/dev/commands/arduino-cli_core_install/). Inclusion of the `--additional-urls` flag in the other commands doesn't cause any problems, but it also doesn't provide any benefit.

The `--additional-urls` flag is hereby removed from the commands where it is not required. This avoids unnecessary length and complexity in the commands.